### PR TITLE
Fix seo issue

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -2,8 +2,8 @@ const formatSeo = (seoRes) => {
   if (!seoRes) return {};
 
   const seo = {
-    metaTitle: seoRes.metaTitle,
-    metaDescription: seoRes.metaDescription,
+    metaTitle: seoRes.metaTitle || null,
+    metaDescription: seoRes.metaDescription || null,
     shareImage: seoRes.metaImage || null,
     structuredData: null,
     metaViewport: null,


### PR DESCRIPTION
Build issue cropped up with `undefined` value for metaTitle. Sets default to `null` to avoid `getStaticProps` compile time issue if metaTitle isnt set

```
Error: Error serializing `.seo.metaTitle` returned from `getStaticProps` in "/ogv-dashboard".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```