### PR TITLE
fix: show 404 instead of error if article is not found

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { fetchAPI } from "../lib/api";
 import Article from "../src/components/Article";
 import transformLinks from "../src/utils/transformLinks";
+import Error404 from "./404";
 
 const FallbackRenderer = ({ article, navLinks }) => {
+  if (!article || !article?.length) return <Error404 navLinks={navLinks} />;
   return <Article article={article} navLinks={navLinks} />;
 };
 


### PR DESCRIPTION
Fixes [OUSD-MARKETING-16T](https://origin-protocol.sentry.io/issues/4059715763/?project=4504532247314432&query=is%3Aunresolved&referrer=issue-stream&stream_index=0).

I haven't touched this codebase before and am pretty ignorant of next.js.  The Sentry E-mails were just bugging me.  Let me know if there's a better approach. :sweat_smile: 