### PR TITLE
Add more safeguards around dom operations

### DIFF
--- a/src/ogv-dashboard/chart-configs/priceLineOptions.ts
+++ b/src/ogv-dashboard/chart-configs/priceLineOptions.ts
@@ -38,7 +38,7 @@ const priceLineOptions: ChartOptions<"line"> = {
           tooltipEl = document.createElement("div");
           tooltipEl.id = "ogv-price-tooltip";
           tooltipEl.innerHTML = "<table></table>";
-          chart.appendChild(tooltipEl);
+          chart?.appendChild(tooltipEl);
         }
 
         // Hide if no tooltip

--- a/src/ogv-dashboard/chart-configs/stakeLineOptions.ts
+++ b/src/ogv-dashboard/chart-configs/stakeLineOptions.ts
@@ -36,7 +36,7 @@ const stakeLineOptions: ChartOptions<"line"> = {
           tooltipEl = document.createElement("div");
           tooltipEl.id = "ogv-staking-tooltip";
           tooltipEl.innerHTML = "<table></table>";
-          chart.appendChild(tooltipEl);
+          chart?.appendChild(tooltipEl);
         }
 
         // Hide if no tooltip

--- a/src/plugins/DistributionLegend.ts
+++ b/src/plugins/DistributionLegend.ts
@@ -16,7 +16,7 @@ const getOrCreateLegendList = (chart, id) => {
       },
     }) as HTMLUListElement;
 
-    legendContainer.appendChild(listContainer);
+    legendContainer?.appendChild(listContainer);
   }
 
   return listContainer;
@@ -115,7 +115,7 @@ export const distributionLegendPlugin: (id: string) => Plugin = (
         }
       }
 
-      ul.appendChild(li);
+      ul?.appendChild(li);
 
       const mediaQuery = window.matchMedia(`(min-width: ${smSize}px)`);
       mediaQuery.addEventListener("change", checkMq);
@@ -139,7 +139,7 @@ const createElement = (
 
   if (children.length > 0) {
     children.forEach((child) => {
-      element.appendChild(child);
+      element?.appendChild(child);
     });
   }
 

--- a/src/proof-of-yield/utils/createTooltip.ts
+++ b/src/proof-of-yield/utils/createTooltip.ts
@@ -16,7 +16,7 @@ const createTooltip = (graphId: number) => {
       tooltipEl = document.createElement("div");
       tooltipEl.id = "dripper-tooltip" + graphId;
       tooltipEl.innerHTML = "<table></table>";
-      chart.appendChild(tooltipEl);
+      chart?.appendChild(tooltipEl);
     }
 
     // Hide if no tooltip

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -84,9 +84,9 @@ export function exportToCsv(filename, rows) {
       link.setAttribute("href", url);
       link.setAttribute("download", filename);
       link.style.visibility = "hidden";
-      document.body.appendChild(link);
+      document?.body?.appendChild(link);
       link.click();
-      document.body.removeChild(link);
+      document?.body.removeChild(link);
     }
   }
 }


### PR DESCRIPTION
- Add client-side safeguards for chart plugins that have `.appendChild` or `.querySelector` usage