### PR TITLE
Generic `ErrorBoundary` and ioredis caching error adjustment

### DIFF
--- a/lib/dune/index.ts
+++ b/lib/dune/index.ts
@@ -65,6 +65,7 @@ class DuneClient {
         tls: {
           rejectUnauthorized: false,
         },
+        connectTimeout: 5000,
         lazyConnect: true,
         retryStrategy(times) {
           if (times > 5) return null;
@@ -80,6 +81,7 @@ class DuneClient {
 
   private async _checkCache<T>(key) {
     try {
+      if (this.cacheClient.status !== CACHE_READY_STATE) return null;
       return JSON.parse(await this.cacheClient.get(key));
     } catch (error) {
       console.error(

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-chartjs-2": "^5.1.0",
     "react-device-detect": "^2.2.3",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.3",
     "react-loader-spinner": "^5.3.4",
     "react-minimal-pie-chart": "^8.3.0",
     "react-moment": "^1.1.2",

--- a/pages/analytics/collateral.tsx
+++ b/pages/analytics/collateral.tsx
@@ -14,7 +14,12 @@ import {
   Chart as ChartJS,
   LinearScale,
 } from "chart.js";
-import { LayoutBox, Image, TwoColumnLayout } from "../../src/components";
+import {
+  ErrorBoundary,
+  LayoutBox,
+  Image,
+  TwoColumnLayout,
+} from "../../src/components";
 import { DurationFilter } from "../../src/analytics/components";
 import {
   aggregateCollateral,
@@ -257,10 +262,11 @@ const CollateralPoolDistributions = ({ data = [] }) => {
 
 const AnalyticsCollateral = ({ strategies, collateral }) => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Collateral</title>
       </Head>
+
       <div className="grid grid-cols-12 gap-6">
         <div className="col-span-12">
           <CollateralAggregate data={collateral} />
@@ -272,7 +278,7 @@ const AnalyticsCollateral = ({ strategies, collateral }) => {
           <CollateralPoolDistributions data={strategies} />
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/dripper.tsx
+++ b/pages/analytics/dripper.tsx
@@ -1,12 +1,16 @@
 import Head from "next/head";
 import { GetServerSideProps } from "next";
 import { Typography } from "@originprotocol/origin-storybook";
-import { LayoutBox, TwoColumnLayout } from "../../src/components";
+import {
+  ErrorBoundary,
+  LayoutBox,
+  TwoColumnLayout,
+} from "../../src/components";
 
 // TODO: Dripper Port
 const AnalyticsDripper = () => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Dripper</title>
       </Head>
@@ -45,7 +49,7 @@ const AnalyticsDripper = () => {
           </div>
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/health-monitoring.tsx
+++ b/pages/analytics/health-monitoring.tsx
@@ -1,7 +1,10 @@
-import { GetServerSideProps } from "next";
 import { Typography } from "@originprotocol/origin-storybook";
 import Head from "next/head";
-import { LayoutBox, TwoColumnLayout } from "../../src/components";
+import {
+  ErrorBoundary,
+  LayoutBox,
+  TwoColumnLayout,
+} from "../../src/components";
 
 const monitoring = {
   macro: [
@@ -70,7 +73,7 @@ const monitoring = {
 
 const AnalyticsHealthMonitoring = () => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Health Monitoring</title>
       </Head>
@@ -169,16 +172,8 @@ const AnalyticsHealthMonitoring = () => {
           </div>
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (): Promise<{
-  props;
-}> => {
-  return {
-    props: {},
-  };
 };
 
 export default AnalyticsHealthMonitoring;

--- a/pages/analytics/holders.tsx
+++ b/pages/analytics/holders.tsx
@@ -1,15 +1,15 @@
 import Head from "next/head";
-import { TwoColumnLayout } from "../../src/components";
+import { ErrorBoundary, TwoColumnLayout } from "../../src/components";
 import { GetServerSideProps } from "next";
 
 const AnalyticsHolders = () => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Holders</title>
       </Head>
       <div>TODO: Holders Breakdown</div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/index.tsx
+++ b/pages/analytics/index.tsx
@@ -17,7 +17,11 @@ import {
 } from "chart.js";
 import { last, orderBy } from "lodash";
 import { Typography } from "@originprotocol/origin-storybook";
-import { LayoutBox, TwoColumnLayout } from "../../src/components";
+import {
+  ErrorBoundary,
+  LayoutBox,
+  TwoColumnLayout,
+} from "../../src/components";
 import { formatCurrency, formatPercentage } from "../../src/utils/math";
 import { aggregateCollateral, chartOptions } from "../../src/analytics/utils";
 import {
@@ -50,7 +54,7 @@ ChartJS.register(
 
 const APYChartContainer = () => {
   const [{ data, filter, isFetching }, { onChangeFilter }] = useAPYChart();
-  return (
+  return data ? (
     <LayoutBox
       loadingClassName="flex items-center justify-center h-[350px] w-full"
       isLoading={isFetching}
@@ -89,7 +93,7 @@ const APYChartContainer = () => {
         <Line options={chartOptions} data={data} />
       </div>
     </LayoutBox>
-  );
+  ) : null;
 };
 
 const TotalSupplyChartContainer = () => {
@@ -100,47 +104,49 @@ const TotalSupplyChartContainer = () => {
       loadingClassName="flex items-center justify-center h-[370px] w-full"
       isLoading={isFetching}
     >
-      <div className="flex flex-row justify-between w-full h-[210px] p-4 md:p-6">
-        <div className="flex flex-col w-full h-full">
-          <Typography.Caption className="text-subheading">
-            Total Supply
-          </Typography.Caption>
-          <Typography.H4>{`${formatCurrency(
-            last(data?.datasets?.[0]?.data) || 0,
-            2
-          )}`}</Typography.H4>
-          <div className="flex flex-col text-sm mb-2">
-            <div className="flex flex-row items-center space-x-2">
-              <div className="w-[6px] h-[6px] bg-gradient3 rounded-full" />
-              <Typography.Caption className="text-subheading">
-                Circulating OUSD
-              </Typography.Caption>
+      <ErrorBoundary>
+        <div className="flex flex-row justify-between w-full h-[210px] p-4 md:p-6">
+          <div className="flex flex-col w-full h-full">
+            <Typography.Caption className="text-subheading">
+              Total Supply
+            </Typography.Caption>
+            <Typography.H4>{`${formatCurrency(
+              last(data?.datasets?.[0]?.data) || 0,
+              2
+            )}`}</Typography.H4>
+            <div className="flex flex-col text-sm mb-2">
+              <div className="flex flex-row items-center space-x-2">
+                <div className="w-[6px] h-[6px] bg-gradient3 rounded-full" />
+                <Typography.Caption className="text-subheading">
+                  Circulating OUSD
+                </Typography.Caption>
+              </div>
+              {/*<div className="flex flex-row items-center space-x-2">*/}
+              {/*  <div className="w-[6px] h-[6px] bg-gradient2 rounded-full" />*/}
+              {/*  <Typography.Caption className="text-subheading">*/}
+              {/*    Protocol-owned OUSD*/}
+              {/*  </Typography.Caption>*/}
+              {/*</div>*/}
             </div>
-            {/*<div className="flex flex-row items-center space-x-2">*/}
-            {/*  <div className="w-[6px] h-[6px] bg-gradient2 rounded-full" />*/}
-            {/*  <Typography.Caption className="text-subheading">*/}
-            {/*    Protocol-owned OUSD*/}
-            {/*  </Typography.Caption>*/}
-            {/*</div>*/}
+            <Typography.Caption className="text-subheading">
+              {last(data?.labels)}
+            </Typography.Caption>
           </div>
-          <Typography.Caption className="text-subheading">
-            {last(data?.labels)}
-          </Typography.Caption>
+          <div className="flex flex-col space-y-2">
+            <DurationFilter
+              value={filter?.duration}
+              onChange={(duration) => {
+                onChangeFilter({
+                  duration: duration || "all",
+                });
+              }}
+            />
+          </div>
         </div>
-        <div className="flex flex-col space-y-2">
-          <DurationFilter
-            value={filter?.duration}
-            onChange={(duration) => {
-              onChangeFilter({
-                duration: duration || "all",
-              });
-            }}
-          />
+        <div className="mr-6">
+          <Line options={chartOptions} data={data} />
         </div>
-      </div>
-      <div className="mr-6">
-        <Line options={chartOptions} data={data} />
-      </div>
+      </ErrorBoundary>
     </LayoutBox>
   );
 };
@@ -149,38 +155,40 @@ const OUSDMarketshareContainer = () => {
   const [{ data, filter, isFetching }, { onChangeFilter }] =
     useMarketshareChart();
   // @ts-ignore
-  return (
+  return data ? (
     <LayoutBox
       loadingClassName="flex items-center justify-center h-[370px] w-full"
       isLoading={isFetching}
     >
-      <div className="flex flex-row justify-between w-full h-[180px] p-4 md:p-6">
-        <div className="flex flex-col w-full h-full">
-          <DefaultChartHeader
-            title="OUSD stablecoin market share on Ethereum"
-            display={`${formatCurrency(
-              last(data?.datasets?.[0]?.data) || 0,
-              4
-            )}%`}
-            date={last(data?.labels)}
-          />
+      <ErrorBoundary>
+        <div className="flex flex-row justify-between w-full h-[180px] p-4 md:p-6">
+          <div className="flex flex-col w-full h-full">
+            <DefaultChartHeader
+              title="OUSD stablecoin market share on Ethereum"
+              display={`${formatCurrency(
+                last(data?.datasets?.[0]?.data) || 0,
+                4
+              )}%`}
+              date={last(data?.labels)}
+            />
+          </div>
+          <div className="flex flex-col space-y-2">
+            <DurationFilter
+              value={filter?.duration}
+              onChange={(duration) => {
+                onChangeFilter({
+                  duration: duration || "all",
+                });
+              }}
+            />
+          </div>
         </div>
-        <div className="flex flex-col space-y-2">
-          <DurationFilter
-            value={filter?.duration}
-            onChange={(duration) => {
-              onChangeFilter({
-                duration: duration || "all",
-              });
-            }}
-          />
+        <div className="mr-6">
+          <Line options={chartOptions} data={data} />
         </div>
-      </div>
-      <div className="mr-6">
-        <Line options={chartOptions} data={data} />
-      </div>
+      </ErrorBoundary>
     </LayoutBox>
-  );
+  ) : null;
 };
 
 const CurrentCollateralContainer = ({ data }) => {
@@ -206,68 +214,70 @@ const CurrentCollateralContainer = ({ data }) => {
     }, 0);
   }, [JSON.stringify(data)]);
 
-  return (
+  return data ? (
     <LayoutBox
       className="min-h-[370px]"
       loadingClassName="flex items-center justify-center w-full h-[370px]"
     >
-      <div className="flex flex-row justify-between w-full h-[80px] p-4 md:p-6">
-        <div className="flex flex-col w-full h-full">
-          <Typography.Caption className="text-subheading">
-            Current Collateral
-          </Typography.Caption>
+      <ErrorBoundary>
+        <div className="flex flex-row justify-between w-full h-[80px] p-4 md:p-6">
+          <div className="flex flex-col w-full h-full">
+            <Typography.Caption className="text-subheading">
+              Current Collateral
+            </Typography.Caption>
+          </div>
         </div>
-      </div>
-      <div className="grid grid-cols-2 gap-4 w-full pb-4">
-        <div className="flex flex-col items-center justify-center flex-shrink-0 w-full h-[350px] px-6">
-          <Doughnut
-            options={{
-              responsive: true,
-              plugins: {
-                title: {
-                  display: false,
+        <div className="grid grid-cols-2 gap-4 w-full pb-4">
+          <div className="flex flex-col items-center justify-center flex-shrink-0 w-full h-[350px] px-6">
+            <Doughnut
+              options={{
+                responsive: true,
+                plugins: {
+                  title: {
+                    display: false,
+                  },
+                  legend: {
+                    display: false,
+                  },
+                  tooltip: {
+                    enabled: false,
+                  },
                 },
-                legend: {
-                  display: false,
-                },
-                tooltip: {
-                  enabled: false,
-                },
-              },
-              cutout: "75%",
-            }}
-            data={chartData}
-          />
-        </div>
-        <div className="flex flex-col flex-shrink-0 w-full h-full space-y-4 px-6">
-          {data.map(({ label, color, total }) => (
-            <div
-              key={label}
-              className="flex flex-row bg-origin-bg-black bg-opacity-50 rounded-md p-4"
-            >
-              <div className="flex flex-row space-x-4">
-                <div
-                  className="relative top-[6px] flex items-start w-[8px] h-[8px] rounded-full"
-                  style={{
-                    background: color,
-                  }}
-                />
-                <div className="flex flex-col space-y-1">
-                  <Typography.Caption>{label}</Typography.Caption>
-                  <Typography.Caption>
-                    {formatPercentage(total / totalSum)}
-                  </Typography.Caption>
-                  <Typography.Caption className="text-subheading">
-                    ${formatCurrency(total, 2)}
-                  </Typography.Caption>
+                cutout: "75%",
+              }}
+              data={chartData}
+            />
+          </div>
+          <div className="flex flex-col flex-shrink-0 w-full h-full space-y-4 px-6">
+            {data.map(({ label, color, total }) => (
+              <div
+                key={label}
+                className="flex flex-row bg-origin-bg-black bg-opacity-50 rounded-md p-4"
+              >
+                <div className="flex flex-row space-x-4">
+                  <div
+                    className="relative top-[6px] flex items-start w-[8px] h-[8px] rounded-full"
+                    style={{
+                      background: color,
+                    }}
+                  />
+                  <div className="flex flex-col space-y-1">
+                    <Typography.Caption>{label}</Typography.Caption>
+                    <Typography.Caption>
+                      {formatPercentage(total / totalSum)}
+                    </Typography.Caption>
+                    <Typography.Caption className="text-subheading">
+                      ${formatCurrency(total, 2)}
+                    </Typography.Caption>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      </ErrorBoundary>
     </LayoutBox>
-  );
+  ) : null;
 };
 
 // const CurrentStrategiesChart = () => {
@@ -336,7 +346,7 @@ const CurrentCollateralContainer = ({ data }) => {
 
 const Analytics = ({ collateral }) => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Overview</title>
       </Head>
@@ -360,7 +370,7 @@ const Analytics = ({ collateral }) => {
         {/*  <OUSDChart />*/}
         {/*</div>*/}
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/protocol-revenue.tsx
+++ b/pages/analytics/protocol-revenue.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from "react";
 import Head from "next/head";
 import { Bar } from "react-chartjs-2";
-import { LayoutBox, TwoColumnLayout } from "../../src/components";
+import {
+  ErrorBoundary,
+  LayoutBox,
+  TwoColumnLayout,
+} from "../../src/components";
 import classnames from "classnames";
 import { Typography } from "@originprotocol/origin-storybook";
 import {
@@ -10,15 +14,13 @@ import {
   Chart as ChartJS,
   LinearScale,
 } from "chart.js";
-import { last, takeRight } from "lodash";
+import { last } from "lodash";
 import {
   DefaultChartHeader,
   DurationFilter,
-  MovingAverageFilter,
 } from "../../src/analytics/components";
 import { useProtocolRevenueChart } from "../../src/analytics/hooks/useProtocolRevenueChart";
 import { formatCurrency } from "../../src/utils/math";
-import { sumOf, sumOfDifferences } from "../../src/analytics/utils";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement);
 
@@ -59,8 +61,7 @@ const ProtocolChart = ({
   chartOptions,
   filter,
 }) => {
-  const dailyRevenue = last(data?.datasets?.[0]?.data);
-  return (
+  return data ? (
     <LayoutBox
       loadingClassName="flex items-center justify-center h-[350px] w-full"
       isLoading={isFetching}
@@ -68,7 +69,7 @@ const ProtocolChart = ({
       <div className="flex flex-row justify-between w-full h-[150px] p-4 md:p-6">
         <DefaultChartHeader
           title="Daily Protocol Revenue"
-          display={`$${formatCurrency(dailyRevenue, 0)}`}
+          display={`$${formatCurrency(last(data?.datasets?.[0]?.data), 0)}`}
           date={last(data?.labels)}
         />
         <div className="flex flex-col space-y-2">
@@ -86,7 +87,7 @@ const ProtocolChart = ({
         <Bar options={chartOptions} data={data} />
       </div>
     </LayoutBox>
-  );
+  ) : null;
 };
 
 const AnalyticsProtocolRevenue = () => {
@@ -121,7 +122,7 @@ const AnalyticsProtocolRevenue = () => {
   }, [JSON.stringify(data)]);
 
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Protocol Revenue</title>
       </Head>
@@ -142,7 +143,7 @@ const AnalyticsProtocolRevenue = () => {
           />
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/strategies.tsx
+++ b/pages/analytics/strategies.tsx
@@ -5,6 +5,7 @@ import { groupBy, orderBy } from "lodash";
 import { Typography } from "@originprotocol/origin-storybook";
 import {
   Button,
+  ErrorBoundary,
   LayoutBox,
   TwoColumnLayout,
   ProgressBar,
@@ -115,7 +116,7 @@ const LookingForYield = () => {
 
 const AnalyticsStrategies = ({ protocols, total }) => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Strategies</title>
       </Head>
@@ -158,7 +159,7 @@ const AnalyticsStrategies = ({ protocols, total }) => {
           <LookingForYield />
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/analytics/supply.tsx
+++ b/pages/analytics/supply.tsx
@@ -23,7 +23,7 @@ import { useQuery } from "react-query";
 import { useMemo, useState } from "react";
 import { createGradient } from "../../src/analytics/utils";
 import { last } from "lodash";
-import { DurationFilter } from "../../src/analytics/components";
+import { ErrorBoundary, DurationFilter } from "../../src/analytics/components";
 import { useSupplyDistributionChart } from "../../src/analytics/hooks/useSupplyDistributionChart";
 
 ChartJS.register(
@@ -409,7 +409,7 @@ const SupplyVolumeBreakdown = () => {
 
 const AnalyticsSupply = () => {
   return (
-    <>
+    <ErrorBoundary>
       <Head>
         <title>Analytics | Supply</title>
       </Head>
@@ -427,7 +427,7 @@ const AnalyticsSupply = () => {
           <SupplyVolumeBreakdown />
         </div>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/pages/api/analytics/charts/ousdMarketshare.ts
+++ b/pages/api/analytics/charts/ousdMarketshare.ts
@@ -8,7 +8,7 @@ export const getOUSDMarketshareRelativeToETH = async () => {
       result: { rows },
     } = await client.refresh(jobsLookup.ousdSupplyRelativeEthereum.queryId);
 
-    rows.reverse();
+    rows?.reverse();
 
     const { total, labels } = toChartData(rows, {
       ousd: "total",
@@ -37,7 +37,9 @@ const getHandler = async (req, res) => {
     return res.json(data);
   } catch (error) {
     return res.status(500).json({
-      error,
+      error:
+        error.message ||
+        "Internal server error on relative eth marketshare query",
     });
   }
 };

--- a/src/analytics/hooks/useAPYChart.ts
+++ b/src/analytics/hooks/useAPYChart.ts
@@ -7,6 +7,7 @@ export const useAPYChart = () => {
     initialData: {
       labels: [],
       datasets: [],
+      error: null,
     },
     refetchOnWindowFocus: false,
     keepPreviousData: true,
@@ -18,6 +19,9 @@ export const useAPYChart = () => {
   });
 
   const chartData = useMemo(() => {
+    if (data?.error) {
+      return null;
+    }
     return formatDisplay(
       filterByDuration(
         {

--- a/src/analytics/hooks/useMarketshareChart.ts
+++ b/src/analytics/hooks/useMarketshareChart.ts
@@ -14,6 +14,7 @@ export const useMarketshareChart = () => {
       initialData: {
         labels: [],
         datasets: [],
+        error: null,
       },
       refetchOnWindowFocus: false,
       keepPreviousData: true,
@@ -25,6 +26,9 @@ export const useMarketshareChart = () => {
   });
 
   const chartData = useMemo(() => {
+    if (data?.error) {
+      return null;
+    }
     return formatDisplay(
       filterByDuration(
         {

--- a/src/analytics/hooks/useProtocolRevenueChart.ts
+++ b/src/analytics/hooks/useProtocolRevenueChart.ts
@@ -10,6 +10,7 @@ export const useProtocolRevenueChart = () => {
       initialData: {
         labels: [],
         datasets: [],
+        error: null,
       },
       refetchOnWindowFocus: false,
       keepPreviousData: true,
@@ -22,6 +23,9 @@ export const useProtocolRevenueChart = () => {
   });
 
   const baseData = useMemo(() => {
+    if (data?.error) {
+      return null;
+    }
     return {
       labels: data?.labels,
       datasets: data?.datasets?.reduce((acc, dataset) => {
@@ -37,7 +41,9 @@ export const useProtocolRevenueChart = () => {
   }, [JSON.stringify(data)]);
 
   const chartData = useMemo(() => {
-    return formatDisplay(filterByDuration(baseData, chartState?.duration));
+    return baseData
+      ? formatDisplay(filterByDuration(baseData, chartState?.duration))
+      : null;
   }, [JSON.stringify(baseData), chartState?.duration, chartState?.typeOf]);
 
   const onChangeFilter = (value) => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { ErrorBoundary as ReactErrorBoundary } from "react-error-boundary";
+import { Typography } from "@originprotocol/origin-storybook";
+import Button from "./Button";
+
+const fallbackRender = ({ resetErrorBoundary }) => {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col space-y-4 items-center justify-center text-center h-[50vh]"
+    >
+      <Typography.H2
+        as="h1"
+        className="text-2xl md:text-7xl text-gradient2 font-bold"
+      >
+        Ooops...
+      </Typography.H2>
+      <Typography.H3
+        className="text-xl md:text-2xl"
+        style={{ fontWeight: 400 }}
+      >
+        Sorry, an error occurred while loading the view.
+      </Typography.H3>
+      <footer>
+        <Button buttonSize="sm" onClick={resetErrorBoundary}>
+          <Typography.Body2>Please try again</Typography.Body2>
+        </Button>
+      </footer>
+    </div>
+  );
+};
+
+const logError = (error: Error, info: { componentStack: string }) => {
+  // Do something with the error, e.g. log to an external API
+  console.error(error);
+};
+
+const ErrorBoundary = ({ children }) => (
+  <ReactErrorBoundary fallbackRender={fallbackRender} onError={logError}>
+    {children}
+  </ReactErrorBoundary>
+);
+
+export default ErrorBoundary;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,4 @@ export { default as TwoColumnLayout } from "./layouts/TwoColumnLayout";
 export { default as Gradient2Button } from "./Gradient2Button";
 export { default as ProgressBar } from "./ProgressBar";
 export { default as RealTimeStats } from "./RealTimeStats";
+export { default as ErrorBoundary } from "./ErrorBoundary";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,6 +6328,13 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.3.tgz#f811497c06d53ea1206817ee82c6e5c6a27becd9"
+  integrity sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
- Add in component level `ErrorBoundary` wrapper for a more graceful fallback and re-try logic
- Surround charts and top-level pages
- Handle a bug more gracefully when `ioredis` cannot connect to our redis instance

On component or page error you would see this, similar in structure to the 404 with different context
![Screenshot 2023-04-11 130546](https://user-images.githubusercontent.com/762107/231240213-7520bfac-da82-4543-841b-aaa958dff402.png)

**Future:**
Integrate with client-side sentry logging for monitoring 