### PR TITLE
Analytics strategies crash fix

### DIFF
--- a/pages/analytics/strategies.tsx
+++ b/pages/analytics/strategies.tsx
@@ -155,7 +155,7 @@ const AnalyticsStrategies = ({ protocols, total }) => {
             </LayoutBox>
           );
         })}
-{/*        <div className="col-span-12">
+        {/*        <div className="col-span-12">
           <LookingForYield />
         </div>*/}
       </div>
@@ -198,7 +198,7 @@ export const getServerSideProps: GetServerSideProps = async (): Promise<{
         icon: strategyMapping[strategy]?.icon || null,
       };
     })
-    .filter((strategy) => !!strategy.protocol);
+    .filter((strategy) => !!strategy?.protocol);
 
   const protocols = groupBy(yieldSources, "protocol");
 


### PR DESCRIPTION
Fixes a bug when the new flux strategy was added into the OETH side which affected the analytics API return results in the OUSD.com app.
