### PR TITLE
Add i18n coverage for ko and other languages

### DIFF
--- a/locales.js
+++ b/locales.js
@@ -1,1 +1,1 @@
-module.exports = ["en", "es"];
+module.exports = ["en", "es", "tr", "ru", "ko", "vi"];

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -37,6 +37,7 @@ export async function getStaticProps({ params, locale }) {
   if (!data) {
     return {
       notFound: true,
+      revalidate: 5 * 60, // Cache response for 5m
     };
   }
 

--- a/pages/governance.tsx
+++ b/pages/governance.tsx
@@ -16,6 +16,7 @@ import {
   fetchImprovementProposals,
   fetchVoterCount,
 } from "../src/governance/utils";
+import { GetStaticProps } from "next";
 
 const overrideCss = "bg-origin-bg-grey";
 
@@ -65,10 +66,21 @@ const GovernanceInfo = ({
   );
 };
 
-export const getStaticProps = async (): Promise<{
-  props: GovernanceProps;
-  revalidate: number;
-}> => {
+export const getStaticProps: GetStaticProps = async ({
+  locale,
+}): Promise<
+  | {
+      props: GovernanceProps;
+      revalidate: number;
+    }
+  | { notFound: true }
+> => {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+
   const navResPromise = fetchAPI("/ousd-nav-links", {
     populate: {
       links: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -89,7 +89,13 @@ const Home = ({
   );
 };
 
-export async function getStaticProps() {
+export async function getStaticProps({ locale }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+
   const { vault, dripper } = setupContracts();
   const initialTvl = await fetchTvl(vault, dripper);
   const apyHistory = await fetchApyHistory();

--- a/pages/ogv-dashboard.tsx
+++ b/pages/ogv-dashboard.tsx
@@ -146,10 +146,22 @@ const OgvDashboard = ({
   );
 };
 
-export const getStaticProps: GetStaticProps = async (): Promise<{
-  props: DashProps;
-  revalidate: number;
-}> => {
+export const getStaticProps: GetStaticProps = async ({
+  locale,
+}): Promise<
+  | {
+      props: DashProps;
+      revalidate: number;
+    }
+  | {
+      notFound: true;
+    }
+> => {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
   const seoResPromise = fetchAPI("/ousd/page/en/%2Fogv-dashboard");
   const navResPromise = fetchAPI("/ousd-nav-links", {
     populate: {


### PR DESCRIPTION
This adds support for other language locales other than `en` and `es`, per https://github.com/OriginProtocol/ousd.com/issues/197